### PR TITLE
做了一些测试代码和代码的重构

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@
 .idea/**/usage.statistics.xml
 .idea/**/dictionaries
 .idea/**/shelf
+.idea/.name
 
 # Generated files
 .idea/**/contentModel.xml

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -3,6 +3,9 @@
     <JetCodeStyleSettings>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
+    <MarkdownNavigatorCodeStyleSettings>
+      <option name="RIGHT_MARGIN" value="72" />
+    </MarkdownNavigatorCodeStyleSettings>
     <codeStyleSettings language="kotlin">
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </codeStyleSettings>

--- a/src/main/kotlin/LiteralHour.kt
+++ b/src/main/kotlin/LiteralHour.kt
@@ -1,4 +1,5 @@
 import java.time.DayOfWeek
+import java.time.LocalDateTime
 
 /*
  * Copyright (c) 2019 LINE Corporation. All rights reserved.
@@ -6,8 +7,36 @@ import java.time.DayOfWeek
  */
 
 data class LiteralHour(val dayOfWeek: DayOfWeek, val hour: Int, val minute: Int) {
-    fun toMinute(): Long {
-        return (dayOfWeek.value * ONE_DAY_IN_MINUTE + hour * ONE_HOUR_IN_MINUTE + minute).toLong()
+    private fun toMinute(): Long {
+        return toMinuteWithPrimitives(dayOfWeek.value, hour, minute)
+    }
+
+    fun isBetween(now: LocalDateTime, another: LiteralHour) =
+        toMinute() <= toMinute(now) && another.toMinute() >= toMinute(now)
+
+    private fun toMinute(localDateTime: LocalDateTime): Long {
+        return toMinuteWithPrimitives(localDateTime.dayOfWeek.value, localDateTime.hour, localDateTime.minute)
+    }
+
+    private fun toMinuteWithPrimitives(dayOfWeek: Int, hour: Int, minute: Int): Long {
+        return (dayOfWeek * ONE_DAY_IN_MINUTE + hour * ONE_HOUR_IN_MINUTE + minute)
+    }
+
+    fun isWithinAHour(now: LocalDateTime) =
+        toMinute() - ONE_HOUR_IN_MINUTE <= toMinute(now) && toMinute(now) <= toMinute()
+
+    fun isOverlay(now: LocalDateTime, another: LiteralHour): Boolean {
+        return isWithinAHour(now) || another.isWithinAHour(now)
+    }
+
+    fun overlayOperationStage(
+        now: LocalDateTime,
+        positive: String,
+        negative: String
+    ) = if (toMinute(now) == toMinute()) {
+        positive
+    } else {
+        negative
     }
 
     companion object {

--- a/src/main/kotlin/OpeningHours.kt
+++ b/src/main/kotlin/OpeningHours.kt
@@ -8,57 +8,16 @@ import java.time.LocalDateTime
 data class OpeningHours(val beginHour: LiteralHour, val endHour: LiteralHour) {
 
     fun operationStage(localDateTime: LocalDateTime): String {
-        val dateTime = toMinute(localDateTime)
-        if (isOverlay(dateTime)) {
-            if (isWithinAHour(beginHour.toMinute(), dateTime)) {
-                return overlayOperationStage(dateTime, beginHour.toMinute(), "Open", "Open Soon")
+        return if (beginHour.isOverlay(localDateTime, endHour)) {
+            if (beginHour.isWithinAHour(localDateTime)) {
+                beginHour.overlayOperationStage(localDateTime, "Open", "Open Soon")
+            } else {
+                endHour.overlayOperationStage(localDateTime, "Close", "Close Soon")
             }
-            return overlayOperationStage(dateTime, endHour.toMinute(), "Close", "Close Soon")
-        }
-
-        return when {
-            !isBetween(dateTime) -> "Close"
-            else -> "Open"
+        } else {
+            if (beginHour.isBetween(localDateTime, endHour)) "Open" else "Close"
         }
     }
 
-    private fun toMinute(localDateTime: LocalDateTime): Long {
-        return (localDateTime.dayOfWeek.value * ONE_DAY_IN_MINUTE + localDateTime.hour * ONE_HOUR_IN_MINUTE + localDateTime.minute).toLong()
-    }
-
-    private fun isBetween(now: Long) = beginHour.toMinute() <= now && endHour.toMinute() >= now
-
-    private fun overlayOperationStage(
-        target: Long,
-        now: Long,
-        positive: String,
-        negative: String
-    ) = if (now == target) {
-        positive
-    } else {
-        negative
-    }
-
-    private fun isWithinAHour(target: Long, now: Long) =
-        target - ONE_HOUR_IN_MINUTE <= now && now <= target
-
-    private fun isOverlay(now: Long): Boolean {
-        return isWithinAHour(beginHour.toMinute(), now) || isWithinAHour(endHour.toMinute(), now)
-    }
-
-    companion object {
-        private const val ONE_HOUR_IN_MINUTE = 60L
-        private const val ONE_DAY_IN_MINUTE = 24 * ONE_HOUR_IN_MINUTE
-    }
 }
 
-fun reduceOpening(first: String, second: String): String {
-    if (first.equals("Close Soon", false) && second.equals("Open Soon", false)) {
-        return first
-    }
-
-    return when (first) {
-        "Close" -> second
-        else -> first
-    }
-}

--- a/src/main/kotlin/StoreBusinessHours.kt
+++ b/src/main/kotlin/StoreBusinessHours.kt
@@ -5,14 +5,17 @@ import java.time.LocalDateTime
  * LINE Corporation PROPRIETARY/CONFIDENTIAL. Use is subject to license terms.
  */
 
-class StoreBusinessHours {
-    private lateinit var serviceHours: List<OpeningHours>
-
-    fun setOpeningHours(openingHours: List<OpeningHours>) {
-        this.serviceHours = openingHours;
-    }
+class StoreBusinessHours(private val serviceHours: List<OpeningHours>) {
 
     fun query(localDateTime: LocalDateTime): String {
         return serviceHours.map { it.operationStage(localDateTime) }.reduce { first, second -> reduceOpening(first, second) }
+    }
+
+    private fun reduceOpening(first: String, second: String): String {
+        return if (first.equals("Close Soon", false) && second.equals("Open Soon", false)) {
+            first
+        } else {
+            if (first == "Close") second else first
+        }
     }
 }

--- a/src/test/kotlin/StoreBusinessHoursTest.kt
+++ b/src/test/kotlin/StoreBusinessHoursTest.kt
@@ -1,5 +1,5 @@
+
 import junit.framework.Assert.assertEquals
-import org.junit.Before
 import org.junit.Test
 import java.time.DayOfWeek
 import java.time.LocalDateTime
@@ -10,12 +10,7 @@ import java.time.LocalDateTime
  */
 
 class StoreBusinessHoursTest {
-    private lateinit var storeBusinessHours: StoreBusinessHours
-
-    @Before
-    fun setup() {
-        storeBusinessHours = StoreBusinessHours()
-    }
+    private lateinit var openingHoursList: List<OpeningHours>
 
     @Test
     fun testClose_MoreThanOneHoursBeforeOpen() {
@@ -165,11 +160,11 @@ class StoreBusinessHoursTest {
     }
 
     private fun givenOpeningHours(vararg openingHours: OpeningHours) {
-        storeBusinessHours.setOpeningHours(openingHours.toList())
+        openingHoursList = openingHours.toList()
     }
 
     private fun shouldBe(expectedResult: String, localDateTime: LocalDateTime) {
-        assertEquals(expectedResult, storeBusinessHours.query(localDateTime))
+        assertEquals(expectedResult, StoreBusinessHours(openingHoursList).query(localDateTime))
     }
 
     private fun openingHours(beginHour: Int, beginMinute: Int, endHour: Int, endMinute: Int): OpeningHours {

--- a/src/test/kotlin/StoreBusinessHoursTest.kt
+++ b/src/test/kotlin/StoreBusinessHoursTest.kt
@@ -19,144 +19,166 @@ class StoreBusinessHoursTest {
 
     @Test
     fun testClose_MoreThanOneHoursBeforeOpen() {
-        givenOneBusinessHours()
+        givenOpeningHours(
+            openingHours(
+                10, 0,
+                12, 0
+            )
+        )
 
-        shouldBe("Close", LocalDateTime.of(2019, 9, 2, 8, 59))
+        shouldBe("Close", currentHourAndMinute(8, 59))
     }
 
     @Test
     fun testOpenSoon_OneHourBeforeOpen() {
-        givenOneBusinessHours()
+        givenOpeningHours(
+            openingHours(
+                10, 0,
+                12, 0
+            )
+        )
 
-        shouldBe("Open Soon", LocalDateTime.of(2019, 9, 2, 9, 0))
+        shouldBe("Open Soon", currentHourAndMinute(9, 0))
+        shouldBe("Open Soon", currentHourAndMinute(9, 59))
     }
 
     @Test
     fun testOpen_OnOpen() {
-        givenOneBusinessHours()
+        givenOpeningHours(
+            openingHours(
+                10, 0,
+                12, 0
+            )
+        )
 
-        shouldBe("Open", LocalDateTime.of(2019, 9, 2, 10, 0))
+        shouldBe("Open", currentHourAndMinute(10, 0))
+        shouldBe("Open", currentHourAndMinute(10, 59))
     }
 
     @Test
     fun testCloseSoon_OneHourBeforeClose() {
-        givenOneBusinessHours()
+        givenOpeningHours(
+            openingHours(
+                10, 0,
+                12, 0
+            )
+        )
 
-        shouldBe("Close Soon", LocalDateTime.of(2019, 9, 2, 11, 0))
+        shouldBe("Close Soon", currentHourAndMinute(11, 0))
+        shouldBe("Close Soon", currentHourAndMinute(11, 59))
     }
 
     @Test
     fun testClose_OnClose() {
-        givenOneBusinessHours()
+        givenOpeningHours(
+            openingHours(
+                10, 0,
+                12, 0
+            )
+        )
 
-        shouldBe("Close", LocalDateTime.of(2019, 9, 2, 12, 0))
+        shouldBe("Close", currentHourAndMinute(12, 0))
     }
 
     @Test
     fun testOpenSoon_OneHoursBeforeSecondOpen_TwoBusinessHours() {
-        givenTwoBusinessHours()
+        givenOpeningHours(
+            openingHours(10, 0, 12, 0),
+            openingHours(14, 0, 16, 0)
+        )
 
-        shouldBe("Open Soon", LocalDateTime.of(2019, 9, 2, 13, 0))
+        shouldBe("Open Soon", currentHourAndMinute(13, 0))
+        shouldBe("Open Soon", currentHourAndMinute(13, 59))
     }
 
     @Test
     fun testCloseSoon_OneHoursBeforeSecondClose_TwoBusinessHours() {
-        givenTwoBusinessHours()
+        givenOpeningHours(
+            openingHours(10, 0, 12, 0),
+            openingHours(14, 0, 16, 0)
+        )
 
-        shouldBe("Close Soon", LocalDateTime.of(2019, 9, 2, 15, 0))
+        shouldBe("Close Soon", currentHourAndMinute(15, 0))
+        shouldBe("Close Soon", currentHourAndMinute(15, 59))
     }
 
     @Test
     fun testClose_OneHourAfterSecondClose_TwoBusinessHours() {
-        givenTwoBusinessHours()
+        givenOpeningHours(
+            openingHours(10, 0, 12, 0),
+            openingHours(14, 0, 16, 0)
+        )
 
-        shouldBe("Close", LocalDateTime.of(2019, 9, 2, 17, 0))
+        shouldBe("Close", currentHourAndMinute(16, 0))
     }
 
     @Test
     fun testCloseSoon_HalfHourBeforeFirstCloseAndOneHourBeforeSecondOpen_TwoCloseBusinessHours() {
-        givenTwoCloseBusinessHours()
+        givenOpeningHours(
+            openingHours(10, 0, 12, 0),
+            openingHours(12, 30, 14, 0)
+        )
 
-        shouldBe("Close Soon", LocalDateTime.of(2019, 9, 2, 11, 30))
+        shouldBe("Close Soon", currentHourAndMinute(11, 30))
+        shouldBe("Close Soon", currentHourAndMinute(11, 59))
     }
 
     @Test
     fun testOpenSoon_OnFirstCloseAndHalfHourBeforeSecondOpen_TwoCloseBusinessHours() {
-        givenTwoCloseBusinessHours()
+        givenOpeningHours(
+            openingHours(10, 0, 12, 0),
+            openingHours(12, 30, 14, 0)
+        )
 
-        shouldBe("Open Soon", LocalDateTime.of(2019, 9, 2, 12, 0))
+        shouldBe("Open Soon", currentHourAndMinute(12, 0))
+        shouldBe("Open Soon", currentHourAndMinute(12, 29))
     }
 
     @Test
     fun testCloseSoon_OneHourBeforeClose_CloseHourIsSmallerThanOpenHour() {
-        givenCloseHourIsSmallerThanOpenHour()
+        givenOpeningHours(
+            openingHours(8, 0, 7, 0)
+        )
 
-        shouldBe("Close Soon", LocalDateTime.of(2019, 9, 2, 6, 0))
+        shouldBe("Close Soon", currentHourAndMinute(6, 0))
+        shouldBe("Close Soon", currentHourAndMinute(6, 59))
+        shouldBe("Open", currentHourAndMinute(8, 0))
     }
 
     @Test
     fun testOpenSoon_OneHourBeforeOpen_CloseHourIsSmallerThanOpenHour() {
-        givenCloseHourIsSmallerThanOpenHour()
+        givenOpeningHours(
+            openingHours(8, 0, 7, 0)
+        )
 
-        shouldBe("Open Soon", LocalDateTime.of(2019, 9, 2, 7, 0))
+        shouldBe("Open Soon", currentHourAndMinute(7, 0))
+        shouldBe("Open Soon", currentHourAndMinute(7, 59))
     }
 
     @Test
     fun testOpen_OneHourBeforeOpen_CloseHourIsSmallerThanOpenHour() {
-        givenCloseHourIsSmallerThanOpenHour()
+        givenOpeningHours(
+            openingHours(8, 0, 7, 0)
+        )
 
-        shouldBe("Open", LocalDateTime.of(2019, 9, 2, 8, 0))
+        shouldBe("Open", currentHourAndMinute(8, 0))
     }
 
-    private fun givenOneBusinessHours() {
-        storeBusinessHours.setOpeningHours(
-            listOf(
-                OpeningHours(
-                    LiteralHour(DayOfWeek.MONDAY, 10, 0),
-                    LiteralHour(DayOfWeek.MONDAY, 12, 0)
-                )
-            )
-        )
-    }
-
-    private fun givenTwoBusinessHours() {
-        storeBusinessHours.setOpeningHours(
-            listOf(
-                OpeningHours(
-                    LiteralHour(DayOfWeek.MONDAY, 10, 0),
-                    LiteralHour(DayOfWeek.MONDAY, 12, 0)),
-                OpeningHours(
-                    LiteralHour(DayOfWeek.MONDAY, 14, 0),
-                    LiteralHour(DayOfWeek.MONDAY, 16, 0))
-            )
-        )
-    }
-
-    private fun givenTwoCloseBusinessHours() {
-        storeBusinessHours.setOpeningHours(
-            listOf(
-                OpeningHours(
-                    LiteralHour(DayOfWeek.MONDAY, 10, 0),
-                    LiteralHour(DayOfWeek.MONDAY, 12, 0)),
-                OpeningHours(
-                    LiteralHour(DayOfWeek.MONDAY, 12, 30),
-                    LiteralHour(DayOfWeek.MONDAY, 14, 0))
-            )
-        )
-    }
-
-    private fun givenCloseHourIsSmallerThanOpenHour() {
-        storeBusinessHours.setOpeningHours(
-            listOf(
-                OpeningHours(
-                    LiteralHour(DayOfWeek.MONDAY, 8, 0),
-                    LiteralHour(DayOfWeek.MONDAY, 7, 0)
-                )
-            )
-        )
+    private fun givenOpeningHours(vararg openingHours: OpeningHours) {
+        storeBusinessHours.setOpeningHours(openingHours.toList())
     }
 
     private fun shouldBe(expectedResult: String, localDateTime: LocalDateTime) {
         assertEquals(expectedResult, storeBusinessHours.query(localDateTime))
     }
+
+    private fun openingHours(beginHour: Int, beginMinute: Int, endHour: Int, endMinute: Int): OpeningHours {
+        return OpeningHours(
+            LiteralHour(DayOfWeek.MONDAY, beginHour, beginMinute),
+            LiteralHour(DayOfWeek.MONDAY, endHour, endMinute)
+        )
+    }
+
+    private fun currentHourAndMinute(hour: Int, minute: Int) = LocalDateTime.of(2019, 9, 2, hour, minute)
+
 }


### PR DESCRIPTION
总的来说，我觉得大家在做Kata的时候是费了心思去重构测试代码和代码的，难能可贵。我做了一些进一步的重构，主要是以下两个方面。

1. 测试代码重构主要体现在让测试的意图明确表达出来。重构之前的代码我觉得有点“去重复代码”过度了。我猜想大家是因为 given 中的 openHours 在一些测试中是重复的，所以就提取一个统一的方法（如givenOpeningHours）。但是把这些重复去掉之后，测试意图就看不清了，缺少了“因果关系”中的原因。我重构之后的代码把必要的given数据放回了每个测试中，以此来表达意图。在测试代码重构中，去重复和表达意图都很重要，但是如果“去重复”影响了“表达意图”，我会优先保证“表达意图”。因为重构之后的测试代码复杂度有限，有利于表达意图的“重复”是可以接受的，这会让测试在维护时更容易被理解。

2. 代码重构主要是把属于 LiteralHour 这个类的代码从 OpeningHours 中移动过去，这里的代码臭味主要是“特性嫉妒”。我觉得重构之前的代码把 LiteralHour 这个类独立出来很不错（代码臭味是“原始类型迷恋”），大家应该观察到 weekDay, hour 和 minute 经常一起出现吧。不过，OpeningHours 有不少方法都是对 LiteralHour 进行操作的，需要移动过去。我猜想大家可能对那些方法是否是“特性嫉妒”有疑惑，原因是这些方法里面有一个参数不属于 LiteralHour，就是表示当前时间的now（LocalDateTime 类型）。很多时候，一个方法不会完全只操作一个类的数据，像当前时间这样一个独立数据的情况也不少见。这时候，我一般会选择把方法移动给那个拥有数据最多的类就好了，在这里就是 LiteralHour。移动过去的方法带有一两个外部数据作为参数是完全没问题的。可能在课上的那个query budget 的重构练习给了大家一些“误导”吧，因为那个练习移动方法的重构没有像now这样的外部数据。

先说这些吧，具体大家可以看我重构之后的代码。有问题随时交流哈 🙂
